### PR TITLE
correcting path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <requirejs>
             {
                 "paths": {
-                    "proj4js": "proj4js"
+                    "proj4js": "proj4"
                 }
             }
         </requirejs>


### PR DESCRIPTION
Not 100% sure of correctness of the fix.

Webjar contains file `proj4js/2.2.1/proj4.js`, but the path in config output is `/webjars/proj4js/2.2.1/proj4js.js` (note the double js).
